### PR TITLE
Adding Ansible, Packer, and Vagrant capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+packer/variables.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 packer/variables.json
 ansible/*.retry
+
+# Vagrant
+.vagrant/
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 packer/variables.json
+ansible/*.retry

--- a/README.md
+++ b/README.md
@@ -1,14 +1,21 @@
 # treetracker-server-scripts
 
-Configuration and deployment scripts are being worked on in the `scripts` directory. This sets up a new Ubuntu 16.04 Linux system with the dependencies (Nginx, Node.js, Postgres) required to run the treetracker project code.
+This repo tracks infrastructure as code improvements for the Treetracker project. Right now there is a Packer template used to create a DigitalOcean base image snapshot, and configuration derived from an Ansible playbook. This sets up a new Ubuntu 16.04 Linux system with the dependencies (Nginx, Node.js, Postgres) required to run the treetracker project code.
 
 ## TODO
 
-* Add UFW rule for Nginx
-* Create non-sudo user `treetracker` to run nodejs apps
-* Create deployment script 
-* Add systemd service files
+* Deployment playbook 
+* PM2 for managing node.js apps
 * Configure Nginx
 * Install Certbot
 * Obtain SSL certificate, set up renewal cronjob
-* Packer, Ansible, Terraform, Docker, etc
+
+## Roadmap
+
+These tools will be helpful in improving developer productivity and delivery velocity:
+
+- Vagrant
+- Terraform
+- Docker
+- Docker Compose
+- Kubernetes

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,7 @@ Vagrant.configure("2") do |config|
   config.vm.define "treetracker-app" do |app|
     app.vm.box = "ubuntu/xenial64"
     app.vm.hostname = "treetracker-app"
+    app.vm.network "forwarded_port", guest: 80, host: 8080
     app.vm.provision "ansible" do |ansible|
       ansible.playbook = "ansible/configuration.yml"
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,14 @@
+Vagrant.configure("2") do |config|
+  # define provider configuration
+  config.vm.provider :virtualbox do |v|
+    v.memory = 2048
+  end
+  # define a VM machine configuration
+  config.vm.define "treetracker-app" do |app|
+    app.vm.box = "ubuntu/xenial64"
+    app.vm.hostname = "treetracker-app"
+    app.vm.provision "ansible" do |ansible|
+      ansible.playbook = "ansible/configuration.yml"
+    end
+  end
+end

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+inventory = ./hosts.yml
+host_key_checking = False

--- a/ansible/configuration.retry
+++ b/ansible/configuration.retry
@@ -1,1 +1,0 @@
-default

--- a/ansible/configuration.retry
+++ b/ansible/configuration.retry
@@ -1,0 +1,1 @@
+default

--- a/ansible/configuration.yml
+++ b/ansible/configuration.yml
@@ -1,0 +1,108 @@
+---
+- name: Configure Treetracker App Instance
+  hosts: all
+  gather_facts: false
+
+  pre_tasks:
+    - name: Install python for Ansible to work
+      raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
+      changed_when: false
+
+## Todo here: all the steps in the configuration.sh script in order to prebake
+#  a packer image.
+  tasks:
+    - name: Add 'deploy' user
+      user:
+        name: deploy
+        shell: /bin/bash
+        groups: sudo
+        append: yes
+    - name: Set passwordless sudo
+      lineinfile:
+        path: /etc/sudoers
+        state: present
+        regexp: '^%sudo'
+        line: '%sudo ALL=(ALL) NOPASSWD: ALL'
+        validate: 'visudo -cf %s'
+    - name: Allow OpenSSH in UFW
+      ufw:
+        state: enabled
+        rule: allow
+        name: OpenSSH
+    - name: Disallow password authentication
+      lineinfile:
+        dest: /etc/ssh/sshd_config
+        regexp: "^PasswordAuthentication"
+        line: "PasswordAuthentication no"
+        state: present
+      notify: Restart ssh
+    - name: Disallow root SSH access
+      lineinfile:
+        dest: /etc/ssh/sshd_config
+        regexp: "^PermitRootLogin"
+        line: "PermitRootLogin no"
+        state: present
+      notify: Restart ssh
+    - name: Install Nginx
+      apt:
+        name: nginx
+        state: present
+        update_cache: yes
+        cache_valid_time: 3600
+    - name: Allow Nginx in UFW
+      ufw:
+        state: enabled
+        rule: allow
+        name: Nginx Full
+    - name: Add nodesource gpg key
+      apt_key:
+        url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+        state: present
+    - name: Add nodesource repo
+      apt_repository:
+        repo: deb https://deb.nodesource.com/node_8.x xenial main
+        filename: nodesource
+        state: present
+    - name: add nodesource source repo
+      apt_repository:
+        repo: deb-src https://deb.nodesource.com/node_8.x xenial main
+        filename: nodesource
+        state: present
+    - name: install nodejs
+      apt:
+        name: nodejs
+        state: present
+        update_cache: yes
+        cache_valid_time: 3600
+    - name: add postgres repo key
+      apt_key:
+        url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
+        state: present
+    - name: Add postgres repo
+      apt_repository:
+        filename: pgdg
+        repo: deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main
+        state: present
+    - name: install Postgres
+      apt:
+        name: "{{ item }}"
+        update_cache: true
+        state: present
+        cache_valid_time: 3600
+      with_items:
+        - postgresql-9.6
+        - postgresql-9.6-postgis-2.3
+        - postgresql-contrib-9.6
+        - postgresql-9.6-postgis-scripts
+
+    - name: add 'treetracker' user
+      user:
+        name: treetracker
+        state: present
+        shell: /bin/bash
+        createhome: yes
+  handlers:
+  - name: Restart ssh
+    service:
+      name: ssh
+      state: restarted

--- a/ansible/configuration.yml
+++ b/ansible/configuration.yml
@@ -2,6 +2,7 @@
 - name: Configure Treetracker App Instance
   hosts: all
   gather_facts: false
+  become: true
 
   pre_tasks:
     - name: Install python for Ansible to work
@@ -11,6 +12,11 @@
 ## Todo here: all the steps in the configuration.sh script in order to prebake
 #  a packer image.
   tasks:
+    - name: initial dist upgrade
+      apt:
+        upgrade: dist
+        update_cache: yes
+        cache_valid_time: 3600
     - name: Add 'deploy' user
       user:
         name: deploy

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -1,0 +1,9 @@
+---
+- name: Deploy Treetracker app(s)
+  hosts: treetracker-app
+  tasks:
+    - name: Fetch the latest version of application 1 code
+      git:
+        repo:
+        dest:
+      register: ttadminclone

--- a/ansible/hosts.yml
+++ b/ansible/hosts.yml
@@ -1,0 +1,5 @@
+treetracker-app:
+  hosts:
+    treetracker-instance:
+      ansible_host: xx.xx.xx.xx
+      ansible_user: root

--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -1,0 +1,5 @@
+#cloud-config
+users:
+  - name: deploy
+    ssh_import_id:
+    - gh:jonleibowitz

--- a/packer/README.md
+++ b/packer/README.md
@@ -1,0 +1,9 @@
+The `treetracker-base-image.json` file will create a snapshot image containing the necessary preinstalled bits for treetracker server systems. 
+
+In order to use, copy the `variables.json.example` file to `variables.json` and add a DigitalOcean API key. Install Packer on your system and run:
+
+packer build -var-file=variables.json treetracker-base-image.json
+
+Packer will create a temporary droplet, run the configuration.sh shell script, perform a snapshot, and destroy the temporary droplet. 
+
+The snapshot once created can be used to create new droplets with a standard configuration.

--- a/packer/treetracker-base-image.json
+++ b/packer/treetracker-base-image.json
@@ -1,0 +1,22 @@
+{
+  "variables":{
+    "my_token":""
+  },
+  "builders":[
+    {
+      "type":"digitalocean",
+      "ssh_username":"root",
+      "api_token":"{{ user `my_token` }}",
+      "image":"ubuntu-16-04-x64",
+      "region":"sfo2",
+      "snapshot_name":"tt-test",
+      "size":"s-2vcpu-4gb"
+    }
+  ],
+  "provisioners":[
+    {
+      "type":"shell",
+      "script":"{{template_dir}}/../scripts/configuration.sh"
+    }
+  ]
+}

--- a/packer/treetracker-base-image.json
+++ b/packer/treetracker-base-image.json
@@ -9,14 +9,14 @@
       "api_token":"{{ user `my_token` }}",
       "image":"ubuntu-16-04-x64",
       "region":"sfo2",
-      "snapshot_name":"tt-test",
+      "snapshot_name":"tt-base-{{isotime `20060102-150405`}}",
       "size":"s-2vcpu-4gb"
     }
   ],
   "provisioners":[
     {
-      "type":"shell",
-      "script":"{{template_dir}}/../scripts/configuration.sh"
+      "type":"ansible",
+      "playbook_file":"{{template_dir}}/../ansible/configuration.yml"
     }
   ]
 }

--- a/packer/variables.json.example
+++ b/packer/variables.json.example
@@ -1,0 +1,3 @@
+{
+  "my_token": "insert DO API token here"
+}


### PR DESCRIPTION
Moving functionality from shell scripts into Ansible templates. Initial Packer template for DigitalOcean snapshot automation. Will be adding a Vagrantfile later today for easy local environment setup.

Right now this Ansible code just installs certain prerequisites (node, nginx, postgres) and doesn't do very much configuration, and it does not yet pull in the project source code for deployment. This is very much a work in progress. 